### PR TITLE
Memory usage benchmarking

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,60 @@
+import signal
+import subprocess
+import time
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+
+# Define variables
+CONTAINER_NAME = "redwood-api"
+DOCKERFILE_PATH = "."
+BENCHMARK_DURATION = 20
+BENCHMARK_RUNS = 9
+
+# Build the Docker image
+print("Building Docker image...")
+subprocess.run(["docker", "build", f"-t{CONTAINER_NAME}", DOCKERFILE_PATH], check=True)
+
+memoryUsages = []
+for i in range(BENCHMARK_RUNS):
+  # Run docker stats to collect data
+  statsProcess = subprocess.Popen(["docker", "stats", "--format", "table {{.ID}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}", "--no-trunc"], stdout=subprocess.PIPE, text=True)
+
+  # Run the docker container
+  print("Starting Docker container...")
+  run_output = subprocess.run(["docker", "run", "-d", CONTAINER_NAME], check=True, stdout=subprocess.PIPE, text=True)
+  container_ID = run_output.stdout.strip()
+
+  # Wait for some time to gather data
+  print(f"Waiting for {BENCHMARK_DURATION} seconds to gather data...")
+  time.sleep(BENCHMARK_DURATION)
+
+  # Stop and then delete the container
+  print("Stopping and deleting container...")
+  subprocess.run(["docker", "stop", container_ID], check=True, stdout=subprocess.PIPE)
+  subprocess.run(["docker", "rm", container_ID], check=True, stdout=subprocess.PIPE)
+
+  # Stop the docker stats process and get the output
+  statsProcess.send_signal(signal.SIGINT)
+  statsProcess.wait()
+
+  # Parse the stats output
+  statsOutput = statsProcess.stdout.readlines()
+  containerStats = [line for line in statsOutput if line.startswith(container_ID)]
+  containerMemUsage = [float(line.split('   ')[1].split(' ')[0][:-3]) for line in containerStats]
+
+  memoryUsages.append(containerMemUsage)
+
+# Plot the data
+max_length = max([len(memoryUsage) for memoryUsage in memoryUsages])
+for memoryUsage in memoryUsages:
+  memoryUsage.extend([float("nan")] * (max_length - len(memoryUsage)))
+  plt.plot(memoryUsage, marker='x')
+plt.xlabel("Time (arb.)")
+plt.ylabel("Memory Usage (MiB)")
+plt.show()
+
+# Print the max memory usage
+maxMemoryUsages = [max(memoryUsage) for memoryUsage in memoryUsages]
+print(f"Max memory usage: {max(maxMemoryUsages)} MiB")
+


### PR DESCRIPTION
As well as reducing image size our focus should also include reducing peak memory usage as this is an issue which arises on various cloud services - this either causes failures or promotes the user to an unwanted paid tier.

How to measure the memory usage of a container over time is a question I did/do not know the answer to. [Stack overflow](https://stackoverflow.com/a/58284327) suggested the data available for a single process but I was somewhat hesitant on whether that would reflect full container usage if multiple processes are spawned. In theory one could also script that approach to gather all peak memory usage for each process - maybe an improvement to what I have here.

The easiest and quickest way I could think of was a basic script to gather the results of docker's `stats` command which livestreams container memory usage to the terminal when invoked. This small python script simply:
* Builds the container
* Runs and records `docker stats`
* Runs the container for a set period
* Repeats for a number of runs
* Produces a peak memory usage value and plots of each individual run's memory usage over time.

![Figure_1](https://user-images.githubusercontent.com/56300765/234707683-a30834d1-2ae3-4aa8-b4e2-497d5249a280.png)

The above plot was produced with this basic dockerfile:
```dockerfile
# Dockerfile to build and deploy the api side

FROM node:16-alpine

RUN yarn cache clean

RUN mkdir /app
WORKDIR /app

COPY package.json .
COPY api/package.json ./api/package.json

COPY yarn.lock .
COPY .yarn .yarn
COPY .yarnrc.yml .yarnrc.yml

RUN yarn install
COPY . .

RUN yarn rw build api

CMD ["yarn", "rw", "serve", "api"]

```

I'm not claiming this is the best or most accurate way to measure this metric. This is just what I quickly put together to get the ball rolling benchmarking this quantity.