### PR TITLE
add fly.io Dockerfile

### DIFF
--- a/.fly/migrate.sh
+++ b/.fly/migrate.sh
@@ -1,0 +1,7 @@
+# #!/bin/sh
+
+# This command pushes us over 256MB of RAM at release time
+yarn rw prisma migrate deploy
+
+# run data migrations
+yarn rw data-migrate up

--- a/.fly/start.sh
+++ b/.fly/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+if [ -n $MIGRATE_ON_BOOT ]; then
+  $(dirname $0)/migrate.sh
+fi
+
+yarn rw serve --port ${PORT} $@

--- a/Dockerfiles/flyio/Dockerfile
+++ b/Dockerfiles/flyio/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:18 as base
+
+RUN mkdir /app
+WORKDIR /app
+
+FROM base as build
+COPY package.json package.json
+COPY web/package.json web/package.json
+COPY api/package.json api/package.json
+COPY yarn.lock yarn.lock
+
+RUN --mount=type=cache,mode=0777,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
+
+COPY redwood.toml .
+COPY graphql.config.js .
+
+COPY scripts scripts
+COPY api api
+COPY web web
+RUN yarn rw build
+RUN --mount=type=cache,mode=0777,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn add -W @redwoodjs/cli @redwoodjs/api-server @redwoodjs/internal
+
+
+FROM node:18-slim as release
+ENV NODE_ENV production
+WORKDIR /app
+
+COPY yarn.lock /app/yarn.lock
+COPY package.json /app/package.json
+
+COPY --from=build /app/web/dist /app/web/dist
+COPY --from=build /app/api /app/api
+COPY --from=build /app/scripts /app/scripts
+COPY --from=build /app/redwood.toml /app
+COPY --from=build /app/graphql.config.js /app
+COPY --from=build /app/node_modules /app/node_modules
+
+COPY .env.defaults .
+COPY .fly .fly
+
+EXPOSE 8910
+
+ENTRYPOINT ["sh"]
+CMD [".fly/start.sh"]


### PR DESCRIPTION
Here is a Dockerfile based on the one we're using in production on fly.io.  I modified it to work with the test project here (we're on an older version of rw). I'm using a multi-stage build with separate `build` and `release` stages. After building, I copy the `node_modules` directory into the release image. Both sides run in the same container. 

I couldn't seem to get the prerendering step to work, so I disabled that in the build. I'll attach the error for reference. Also I'm not sure the yarn cache mount is working, though that could be a local issue.