### PR TITLE
feat(api): set up experimental server file

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,10 @@
   "dependencies": {
     "@redwoodjs/api": "5.2.3",
     "@redwoodjs/auth-dbauth-api": "5.2.3",
-    "@redwoodjs/graphql-server": "5.2.3"
+    "@redwoodjs/fastify": "5.2.3",
+    "@redwoodjs/graphql-server": "5.2.3",
+    "@redwoodjs/project-config": "5.2.3",
+    "chalk": "4.1.2",
+    "fastify": "4.17.0"
   }
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,0 +1,66 @@
+import path from 'path'
+
+import chalk from 'chalk'
+import { config } from 'dotenv-defaults'
+import Fastify from 'fastify'
+
+import {
+  coerceRootPath,
+  redwoodFastifyWeb,
+  redwoodFastifyAPI,
+  DEFAULT_REDWOOD_FASTIFY_CONFIG,
+} from '@redwoodjs/fastify'
+import { getPaths, getConfig } from '@redwoodjs/project-config'
+
+async function serve() {
+  // Load .env files
+  const redwoodProjectPaths = getPaths()
+
+  config({
+    path: path.join(redwoodProjectPaths.base, '.env'),
+    defaults: path.join(redwoodProjectPaths.base, '.env.defaults'),
+    multiline: true,
+  })
+
+  const tsServer = Date.now()
+  console.log(chalk.italic.dim('Starting API and Web Servers...'))
+
+  // Configure Fastify
+  const fastify = Fastify({
+    ...DEFAULT_REDWOOD_FASTIFY_CONFIG,
+  })
+
+  const redwoodConfig = getConfig()
+
+  const apiRootPath = coerceRootPath(redwoodConfig.web.apiUrl)
+  const port = redwoodConfig.web.port
+
+  await fastify.register(redwoodFastifyWeb)
+
+  await fastify.register(redwoodFastifyAPI, {
+    redwood: {
+      apiRootPath,
+    },
+  })
+
+  // Start
+  fastify.listen({ port })
+
+  fastify.ready(() => {
+    console.log(chalk.italic.dim('Took ' + (Date.now() - tsServer) + ' ms'))
+    const on = chalk.magenta(`http://localhost:${port}${apiRootPath}`)
+    const webServer = chalk.green(`http://localhost:${port}`)
+    const apiServer = chalk.magenta(`http://localhost:${port}`)
+    console.log(`Web server started on ${webServer}`)
+    console.log(`API serving from ${apiServer}`)
+    console.log(`API listening on ${on}`)
+    const graphqlEnd = chalk.magenta(`${apiRootPath}graphql`)
+    console.log(`GraphQL endpoint at ${graphqlEnd}`)
+  })
+
+  process.on('exit', () => {
+    fastify.close()
+  })
+}
+
+serve()

--- a/redwood.toml
+++ b/redwood.toml
@@ -16,3 +16,6 @@
   open = true
 [notifications]
   versionUpdates = ["latest"]
+
+[experimental.serverFile]
+	enabled = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -7931,7 +7931,11 @@ __metadata:
   dependencies:
     "@redwoodjs/api": 5.2.3
     "@redwoodjs/auth-dbauth-api": 5.2.3
+    "@redwoodjs/fastify": 5.2.3
     "@redwoodjs/graphql-server": 5.2.3
+    "@redwoodjs/project-config": 5.2.3
+    chalk: 4.1.2
+    fastify: ^4.17.0
   languageName: unknown
   linkType: soft
 
@@ -12869,7 +12873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastify@npm:4.17.0":
+"fastify@npm:4.17.0, fastify@npm:^4.17.0":
   version: 4.17.0
   resolution: "fastify@npm:4.17.0"
   dependencies:


### PR DESCRIPTION
We've been working on a server file for Redwood projects. You can set it up via `yarn rw experimental setup-server-file`. It's still experimental, but worth experimenting with here because it means we could run the server without a Redwood binary like the CLI or the api-server. With this server file, running the api server would simply look like `node ./api/dist/server.js`.